### PR TITLE
Fix Vite imports by adding alias

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
+import { fileURLToPath, URL } from 'node:url'
 
 export default defineConfig({
   plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url))
+    }
+  },
   test: {
     globals: true,
     environment: 'jsdom'


### PR DESCRIPTION
## Summary
- fix unresolved component imports by defining `@` alias in Vite config

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6843fb0fd634832dbff1e3e39c13a941