### PR TITLE
Update API paths

### DIFF
--- a/src/components/EventModal.vue
+++ b/src/components/EventModal.vue
@@ -265,7 +265,7 @@ export default {
           this.$emit('close-modal');
       },
       async addDetail(){
-        const url = `${process.env.VUE_APP_API_URL}/api/home/getInfoDetail?category=${this.$store.state.category}&houseManageNo=${this.selected.HOUSE_MANAGE_NO}&pblancNo=${this.selected.PBLANC_NO}`;
+        const url = `${process.env.VUE_APP_API_URL}/api/homes/detail?category=${this.$store.state.category}&houseManageNo=${this.selected.HOUSE_MANAGE_NO}&pblancNo=${this.selected.PBLANC_NO}`;
         await this.fetchData(url).then(data => {
           this.selectedDetail = data
         }).catch(err=>
@@ -274,7 +274,7 @@ export default {
         // console.log(this.selectedDetail);
       },
       async getRate(){
-        const url = `${process.env.VUE_APP_API_URL}/api/home/getRateInfo?houseManageNo=${this.selected.HOUSE_MANAGE_NO}&houseSeCd=${this.selected.HOUSE_SECD}`; 
+        const url = `${process.env.VUE_APP_API_URL}/api/homes/rate?houseManageNo=${this.selected.HOUSE_MANAGE_NO}&houseSeCd=${this.selected.HOUSE_SECD}`;
         await this.fetchData(url).then(data => {
           return this.selectedRate = data
         });

--- a/src/store.js
+++ b/src/store.js
@@ -157,7 +157,7 @@ const store = createStore({
         async getData({commit}){
             // console.log(this.state.category);
             commit('setLoadingbar');            
-            return axios.get(`${process.env.VUE_APP_API_URL}/api/home/getInfo?category=${this.state.category}`).then(res =>{
+            return axios.get(`${process.env.VUE_APP_API_URL}/api/homes?category=${this.state.category}`).then(res =>{
                 const { data } = res.data;
                 commit('setLoadingbar');
                 // console.log(data);
@@ -185,7 +185,7 @@ const store = createStore({
         async getPastData({commit},data){
             commit('setLoadingbar');            
             try{
-                const res = await axios.get(`${process.env.VUE_APP_API_URL}/api/home/getInfo?category=${this.state.category}&s_date=${data.s_date}&e_date=${data.e_date}`);
+                const res = await axios.get(`${process.env.VUE_APP_API_URL}/api/homes?category=${this.state.category}&start=${data.s_date}&end=${data.e_date}`);
                 commit('setLoadingbar');
                 // console.log(res);
                 const result = res.data.data.map((param)=>{


### PR DESCRIPTION
## Summary
- update store and modal components to use new `/api/homes` endpoints

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684442810a80832da6ce85177aad4f5a